### PR TITLE
Moved service level CORS to Proxy

### DIFF
--- a/backend/src/server.pl
+++ b/backend/src/server.pl
@@ -3,11 +3,8 @@
 :- use_module(library(http/http_dispatch)).
 :- use_module(library(http/http_parameters)).
 :- use_module(library(http/http_json)).
-:- use_module(library(http/http_cors)).  % Import CORS library
 :- use_module(logic).  % Import diagnosis logic
 
-% Set CORS setting to allow all origins
-:- set_setting(http:cors, [*]).
 
 % Define HTTP handlers
 :- http_handler(root(diagnose), diagnose_handler, []).
@@ -38,7 +35,6 @@ stop_server :-
 
 % Handle /diagnose?symptoms=symptom1,symptom2
 diagnose_handler(Request) :-
-    cors_enable(Request, [methods([get])]),  % Enable CORS for GET requests
     (   http_parameters(Request, [
             symptoms(SymptomListStr, [optional(true), default("")])
         ])
@@ -51,11 +47,7 @@ diagnose_handler(Request) :-
 
 % Handle /symptoms to get the list of all symptoms
 symptoms_handler(_) :-
-    cors_enable,
     all_symptoms(SortedSymptoms),
     reply_json(SortedSymptoms).
 
-% Enable CORS for all responses
-% :- multifile http:access_control_allow_origin/2.
 :- start_server.
-http:access_control_allow_origin(_, '*').

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -72,7 +72,7 @@
         const selectedSymptoms = new Set();
 
         async function fetchSymptoms() {
-            const response = await fetch('http://localhost:8090/symptoms');
+            const response = await fetch('http://localhost/api/symptoms');
             const symptoms = await response.json();
             const select = document.getElementById('symptom-select');
             symptoms.forEach(symptom => {

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,6 +10,22 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Add CORS headers
+            add_header 'Access-Control-Allow-Origin' 'http://frontend:8080';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization';
+
+            # Handle preflight requests
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' 'http://frontend:8080';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization';
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
         }
 
         location / {


### PR DESCRIPTION
I removed the CORS configuration in our prolog endpoint, this should be handled by our proxy NGINX it is generally better to have the proxy handle the CORS since we would have a standardized configuration for the endpoints we would avoid misconfiguration

Reference:
https://docs.unizen.io/api-introduction/security-best-practices-for-integrating-unizen/how-to-integrate-with-a-reverse-proxy?utm_source=chatgpt.com