### PR TITLE
Updated docker config for development

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,8 @@ services:
       - "8090:8090"
     networks:
       - prolog-network
+    volumes:
+      - ./backend/src:/app/src
 
   frontend:
     build:
@@ -15,6 +17,10 @@ services:
       - "8080:8080"
     networks:
       - prolog-network
+    volumes:
+      - ./frontend:/app
+    environment:
+      - NODE_ENV=development
   
   nginx:
     image: nginx:latest

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./frontend:/app
     environment:
-      - NODE_ENV=development
+      - NODE_ENV=production
   
   nginx:
     image: nginx:latest

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 EXPOSE 3000
 
 # Start the application
-CMD ["npm", "start"]
+CMD ["sh", "-c", "if [ \"$NODE_ENV\" = \"development\" ]; then npm run dev; else npm start; fi"]

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -12,6 +12,10 @@ app.use('/js', express.static(path.join(publicDir, 'js')))
 
 app.use(express.json())
 
+app.get('/health', (req, res) => {
+    res.send('OK')
+}
+)
 
 app.get('/', controller(publicDir))
 


### PR DESCRIPTION
Mounted the volumes for both the backend and frontend so that development can be done without rebuilding the docker containers for changes made

## How to run the application for development
Run the multi container docker app with `NODE_ENV=development docker compose up --build` if you previously ran prev versions of our config, `--build` is not needed afterward unless you have made changes to our docker config. This allows you to run the frontend service via nodemon and it will automatically restart node application if  changes are done with the node files or our frontend directory.

## For Prolog
for prolog if changes are made you would have to start another terminal and run `docker compose restart prolog-api`, this restarts the service, you would only have to open another terminal assuming if you did not run the app in daemon mode